### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=MultiPress
+version=0.0.0
+author=Jim Brower
+maintainer=Jim Brower
+sentence=Small footprint library for enabling multi-press actions to pushbutton switches.
+paragraph=
+category=Signal Input/Output
+url=https://github.com/BulldogLowell/MultiPress
+architectures=*
+includes=MultiPress.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata